### PR TITLE
Don’t cache if compile fails.

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,12 +25,8 @@ function cachingCoffeify(file) {
 
     if (!cached || cached.hash !== hash) {
       coffeeify.compile(file, data, function(error, result) {
-        if (error) {
-          stream.emit('error', error);
-          delete cache[file];
-        } else {
-          cache[file] = { compiled: result, hash: hash };
-        }
+        if (error) return stream.emit('error', error);
+        cache[file] = { compiled: result, hash: hash };
         stream.queue(result);
         stream.queue(null);
       });

--- a/index.js
+++ b/index.js
@@ -25,8 +25,12 @@ module.exports = function (file) {
 
     if (!cached || cached.hash !== hash) {
       coffeeify.compile(file, data, function(error, result) {
-        if (error) stream.emit('error', error);
-        cache[file] = { compiled: result, hash: hash };
+        if (error) {
+          stream.emit('error', error);
+          delete cache[file];
+        } else {
+          cache[file] = { compiled: result, hash: hash };
+        }
         stream.queue(result);
         stream.queue(null);
       });

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ function getHash(data) {
     .digest('hex');
 }
 
-module.exports = function (file) {
+function cachingCoffeify(file) {
   if (!coffeeify.isCoffee(file)) return through();
 
   var data = ''
@@ -42,3 +42,8 @@ module.exports = function (file) {
 
   return stream;
 };
+
+cachingCoffeify.cache = cache;
+
+
+module.exports = cachingCoffeify;

--- a/test/error.js
+++ b/test/error.js
@@ -5,10 +5,10 @@ var fs = require('fs');
 
 var file = path.resolve(__dirname, '../example/error.coffee');
 var multilineFile = path.resolve(__dirname, '../example/multiline_error.coffee');
-var transform = path.join(__dirname, '..');
+var transform = require(path.join(__dirname, '..'));
 
 test('transform error', function (t) {
-    t.plan(5);
+    t.plan(6);
 
     var b = browserify([file]);
     b.transform(transform);
@@ -19,6 +19,7 @@ test('transform error', function (t) {
         t.ok(error.column !== undefined, "error.column should be defined");
         t.equal(error.line, 5, "error should be on line 5");
         t.equal(error.column, 15, "error should be on column 15");
+        t.equal(Object.keys(transform.cache).length, 0, "should not be cached")
     });
 });
 


### PR DESCRIPTION
Syntax errors would not show up the second time compiling before, just writing undefined to the stream.